### PR TITLE
Support Multiple Azurestack's tasks on 1 server

### DIFF
--- a/MasterScript.ps1
+++ b/MasterScript.ps1
@@ -88,11 +88,11 @@ $info = @{
 }
 
 $infoJson = ConvertTo-Json $info
-Set-Content -Path "C:\AZSAdminOMSInt\info.txt" -Value $infoJson
+Set-Content -Path "C:\AZSAdminOMSInt\info_$CloudName.txt" -Value $infoJson
 
 #store passwords in txt files. 
 $passwordText = $azureStackAdminPasswordSecureString | ConvertFrom-SecureString
-Set-Content -Path "C:\AZSAdminOMSInt\azspassword.txt" -Value $passwordText
+Set-Content -Path "C:\AZSAdminOMSInt\azspassword_$CloudName.txt" -Value $passwordText
 
 
 #Download Azure Stack Tools VNext
@@ -102,4 +102,4 @@ expand-archive vnext.zip -DestinationPath . -Force
 
 # schedule windows scheduled task
 cd C:\AZSAdminOMSInt
-& .\schedule_usage_upload.ps1
+& .\schedule_usage_upload.ps1 -CloudName $CloudName

--- a/OpsDataToOMS.ps1
+++ b/OpsDataToOMS.ps1
@@ -1,4 +1,10 @@
-Start-Transcript -Path C:\AZSAdminOMSInt\OpsDataToOMS.log
+[CmdletBinding()]
+param(
+    [Parameter(Mandatory = $true)]
+    [string] $CloudName   
+)
+
+Start-Transcript -Path "C:\AZSAdminOMSInt\OpsDataToOMS_$CloudName.log"
 Set-ExecutionPolicy Bypass -Force
 Install-Module -Name OMSIngestionAPI -Force
 Install-Module -Name AzureRM.OperationalInsights -Force
@@ -9,7 +15,7 @@ Import-Module -Name Azs.Fabric.Admin -Force
 
 #OMS Authentication Variables
 
-$info = Get-Content -Raw -Path "C:\AZSAdminOMSInt\info.txt" | ConvertFrom-Json
+$info = Get-Content -Raw -Path "C:\AZSAdminOMSInt\info_$CloudName.txt" | ConvertFrom-Json
 $OMSWorkspaceId = $info.OmsWorkspaceID 
 $OMSSharedKey = $info.OmsSharedKey
 
@@ -19,7 +25,7 @@ $Location2 = $info.Region
 $cloudName2 = $info.CloudName
 $State2 = "active"
 $UserName2= $info.AzureStackAdminUsername
-$Password2= Get-Content "C:\AZSAdminOMSInt\azspassword.txt"| ConvertTo-SecureString
+$Password2= Get-Content "C:\AZSAdminOMSInt\azspassword_$CloudName.txt"| ConvertTo-SecureString
 $Credential2=New-Object PSCredential($UserName2,$Password2)
 
 $deploymentGuid = $info.DeploymentGuid

--- a/asUsageToOMS.ps1
+++ b/asUsageToOMS.ps1
@@ -1,10 +1,16 @@
-Start-Transcript -Path C:\AZSAdminOMSInt\asUsageToOMS.log
-& .\usagesummaryjson.ps1
+[CmdletBinding()]
+param(
+    [Parameter(Mandatory = $true)]
+    [string] $CloudName   
+)
+
+Start-Transcript -Path "C:\AZSAdminOMSInt\asUsageToOMS_$CloudName.log"
+& .\usagesummaryjson.ps1 -CloudName $CloudName
 
 # set execution policy and import OMS Ingestion API. 
 Set-ExecutionPolicy -ExecutionPolicy Bypass -Force
 Install-Module -Name AzureRM.OperationalInsights -Force
 Install-Module -Name OMSIngestionAPI -Force
 
-& .\uploadToOMS.ps1
+& .\uploadToOMS.ps1 -CloudName $CloudName
 exit

--- a/docs/setup.md
+++ b/docs/setup.md
@@ -68,7 +68,7 @@ The following are required to setup the environment. You should gather these var
 
 ### Step 5 – Execute the script & update the scheduled task
 1.	Run the InvokeMasterScript.ps1 now that the variables have been updated.
-2.	Once the script completes, open Task Scheduler, right click on the newly created tasks named UsageDataUpload1 & OperationalDataUpload1, click Properties, and click "Change User or Group" (the Run As account) to the Admin UserName and Password of the UploadToOMSVM VM.
+2.	Once the script completes, open Task Scheduler, right click on the newly created tasks named UsageDataUpload1_<CloudName> & OperationalDataUpload1_<CloudName>, click Properties, and click "Change User or Group" (the Run As account) to the Admin UserName and Password of the UploadToOMSVM VM.
 3. 	Click Run. Operational Data will be piushed every 13 minutes now. Usage Data will be pushed at 9am every day.
 
 The scripts sets up 2 scheduled tasks: 
@@ -78,6 +78,44 @@ The scripts sets up 2 scheduled tasks:
 The data are uploaded to the OMS workspace you specified in the ARM template. 
 
 Note: For usage data, the script is setup to query and upload usage data reported from the day before yesterday each time the scheduled task runs. Note that no usage data will be uploaded if there are no tenant usage during the timeframe specified. 
+
+## Deploy additional Data Collection scheduled tasks to a data collection VM
+### Step 1 - Get required variables 
+The following are required to setup the environment. You should gather these variables before proceeding to the next step.
+#### DeploymentGUID = “<e.g. 41da4fdd-0e5f-4ecb-85d2-52cb85cd1fca>”
+1. Access the privileged endpoint
+2. Run Get-AzureStackStampInformation
+3. Find and copy the deploymentguid from the output
+#### azureStackAdminUsername ="<e.g. Serviceadmin@myazurestackinstance.onmicrosoft.com>"
+1. Update with the Azure Stack Service Admin account email
+#### azureStackAdminPassword = "<e.g. MyAzureStackPassword206!>"
+1. Update with the Azure Stack Service Admin account password
+#### CloudName ="<e.g. Orlando MTC>"
+1. Update location with the name of your Cloud, this is how most data will pivot in the views. Must be Unique with any AzureStack Tasks already running on the system
+#### Region = "<e.g. Orlando>"
+1. Update with the region name used when deploying Azure Stack
+#### Fqdn = "<e.g. azurestack.corp.microsoft.com>"
+1. Update with the FQDN name used when deploying Azure Stack
+#### OMSWorkpsaceID= "<ID of your log analytics workspace>"
+1. Update with the OMS/Log Analytics Workspace ID which can be found in the Advanced Settings pane of your Log Analytics workspace 
+#### OMSSharedKey = "<Log Analytics Workspace Shared Key>"
+1. Update with the OMS/Log Analytics Workspace Primary Key found in the Advanced Settings pane of your Log Analytics workspace
+#### OEM = "<replace with your hardware vendor name>"
+1. Update with the name of your hardware vendor. Allows for reports in log analytics utilizing the OEM name.
+
+### Step 2 – Update variables
+1.	Open an elevated PowerShell ISE session
+2.	Open the file C:\InvokeMasterScript.ps1
+3.	Update the variables using the data gathered in Step 3
+
+### Step 3 – Execute the script & update the scheduled task
+1.	Run the InvokeMasterScript.ps1 now that the variables have been updated.
+2.	Once the script completes, open Task Scheduler, right click on the newly created tasks named UsageDataUpload1_<CloudName> & OperationalDataUpload1_<CloudName>, click Properties, and click "Change User or Group" (the Run As account) to the Admin UserName and Password of the UploadToOMSVM VM.
+3. 	Click Run. Operational Data will be pushed every 13 minutes now. Usage Data will be pushed at 9am every day.
+
+The scripts sets up 2 scheduled tasks: 
+1. Upload of 1-day worth of usage data provided from the Provider Usage API at 9am every day.
+2. Upload of operational data every 13 minutes.
 
 ## Troubleshooting
 1. To verify that data is getting uploaded to OMS environment:
@@ -154,4 +192,4 @@ For specific documentation on the Power BI dashboard template, refer to the [das
 
 ## Limitations
 1. As of 8/9/2017, there is 8mb size limit on the request that PowerBI uses to fetch data from OMS. This restriction is planned to be lifted in the future by the OMS Log Analytics team.
-2. If the restriction persists, one way to increase the number of days of usage data available (by 24x) is pull in daily aggregated usage data from OMS instead of hourly aggregated data. The obvious drawback for this method is that one will not be able to  drilldown to the hourly level on the PowerBI dashboard. 
+2. If the restriction persists, one way to increase the number of days of usage data available (by 24x) is pull in daily aggregated usage data from OMS instead of hourly aggregated data. The obvious drawback for this method is that one will not be able to  drilldown to the hourly level on the PowerBI dashboard.

--- a/schedule_usage_upload.ps1
+++ b/schedule_usage_upload.ps1
@@ -1,8 +1,14 @@
+[CmdletBinding()]
+param(
+    [Parameter(Mandatory = $true)]
+    [string] $CloudName   
+)
+
 #Usage Data Upload
 $action = New-ScheduledTaskAction -Execute 'Powershell' `
--Argument '.\asUsageToOMS.ps1' -WorkingDirectory "C:\AZSAdminOMSInt"
+-Argument (".\asUsageToOMS.ps1 -CloudName '{0}'" -f $CloudName) -WorkingDirectory "C:\AZSAdminOMSInt"
 $description = "Daily upload of usage data from azure stack to OMS"
-$taskName = "UsageDataUpload1"
+$taskName = "UsageDataUpload1_$CloudName"
 
 $trigger = New-ScheduledTaskTrigger -Daily -At 9am
 $principal = New-ScheduledTaskPrincipal -UserID "NT AUTHORITY\SYSTEM"
@@ -14,9 +20,9 @@ Register-ScheduledTask -Action $action -Trigger $trigger -TaskName $taskName -Pr
 
 #Operational Data Upload
 $action = New-ScheduledTaskAction -Execute 'Powershell' `
--Argument '.\OpsDataToOMS.ps1' -WorkingDirectory "C:\AZSAdminOMSInt"
+-Argument (".\OpsDataToOMS.ps1 -CloudName '{0}'" -f $CloudName) -WorkingDirectory "C:\AZSAdminOMSInt"
 $description = "Daily upload of operational data from azure stack to OMS"
-$taskName = "OperationalDataUpload1"
+$taskName = "OperationalDataUpload1_$CloudName"
 
 $trigger = New-ScheduledTaskTrigger -once -at (Get-date) -RepetitionInterval (New-TimeSpan -Minutes 13) -RepetitionDuration (New-TimeSpan -Days 9999) 
 $principal = New-ScheduledTaskPrincipal -UserID "NT AUTHORITY\SYSTEM"

--- a/uploadToOMS.ps1
+++ b/uploadToOMS.ps1
@@ -1,4 +1,10 @@
-Start-Transcript -Path C:\AZSAdminOMSInt\uploadtoOMS.log
+[CmdletBinding()]
+param(
+    [Parameter(Mandatory = $true)]
+    [string] $CloudName   
+)
+
+Start-Transcript -Path "C:\AZSAdminOMSInt\uploadtoOMS_$CloudName.log"
 Set-ExecutionPolicy Bypass -Force
 Install-Module -Name OMSIngestionAPI -Force
 Install-Module -Name AzureRM.OperationalInsights -Force
@@ -9,7 +15,7 @@ Import-Module -Name Azs.Fabric.Admin -Force
 
 #OMS Authentication Variables
 
-$info = Get-Content -Raw -Path "C:\AZSAdminOMSInt\info.txt" | ConvertFrom-Json
+$info = Get-Content -Raw -Path "C:\AZSAdminOMSInt\info_$CloudName.txt" | ConvertFrom-Json
 $OMSWorkspaceId = $info.OmsWorkspaceID 
 $OMSSharedKey = $info.OmsSharedKey
 
@@ -18,7 +24,7 @@ $Location2 = $info.Region
 $cloudName2 = $info.CloudName
 $State2 = "active"
 $UserName2= $info.AzureStackAdminUsername
-$Password2= Get-Content "C:\AZSAdminOMSInt\azspassword.txt"| ConvertTo-SecureString
+$Password2= Get-Content "C:\AZSAdminOMSInt\azspassword_$CloudName.txt"| ConvertTo-SecureString
 $Credential2=New-Object PSCredential($UserName2,$Password2)
 
 $deploymentGuid = $info.DeploymentGuid

--- a/usagesummaryjson.ps1
+++ b/usagesummaryjson.ps1
@@ -8,7 +8,13 @@
     .EXAMPLE
     Export-AzureStackUsage -StartTime 2/15/2017 -EndTime 2/16/2017 -AzureStackDomain azurestack.local -AADDomain mydir.onmicrosoft.com -Granularity Hourly
 #>
-Start-Transcript -Path C:\AZSAdminOMSInt\usagesummaryjson.log
+[CmdletBinding()]
+param(
+    [Parameter(Mandatory = $true)]
+    [string] $CloudName   
+)
+
+Start-Transcript -Path "C:\AZSAdminOMSInt\usagesummaryjson_$CloudName.log"
 
 function Export-AzureStackUsage {
     Param
@@ -194,9 +200,9 @@ $dayBeforeYesterday = $yesterday.addDays(-1)
 $usageStartTime = $dayBeforeYesterday.ToShortDateString()
 $usageEndTime = $yesterday.ToShortDateString()
 
-$info = Get-Content -Raw -Path "C:\AZSAdminOMSInt\info.txt" | ConvertFrom-Json
+$info = Get-Content -Raw -Path "C:\AZSAdminOMSInt\info_$CloudName.txt" | ConvertFrom-Json
 $Username = $info.AzureStackAdminUsername
-$Password= Get-Content "C:\AZSAdminOMSInt\azspassword.txt"| ConvertTo-SecureString
+$Password= Get-Content "C:\AZSAdminOMSInt\azspassword_$CloudName.txt"| ConvertTo-SecureString
 $aadCred = New-Object PSCredential($Username, $Password)
 $cloudName2 = $info.CloudName
 $Location2 = $info.Region 


### PR DESCRIPTION
Changing how the Tasks, Logs, Info.txt and Password.txt are created so multiple AZURESTACKs' tasks could be run from a single server.
This relies on the value provided to CloudName when running MasterScript to be unique on that server.
Old Tasks will need to be recreated to function with the new scripts.

## Purpose
Making it so multiple AZURESTACKs' tasks could be run from a single server.

## Does this introduce a breaking change?
```
[X] Yes
[ ] No
```

## Pull Request Type
What kind of change does this Pull Request introduce?

```
[ ] Bugfix
[X] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Documentation content changes
[ ] Other... Please describe:
```

## How to Test
*  Get the code

```
git clone [repo-address]
cd [repo-name]
git checkout [branch-name]
npm install
```

* Test the code
Can be run by just running the Invoke-MasterScript.ps1 more then once with the CloudName value being unique between runs
```
```

## What to Check
Verify that the following are valid
* ...

## Other Information
<!-- Add any other helpful information that may be needed here. -->